### PR TITLE
TASK: Update `neos/neos` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "neos-package",
     "name": "wwwision/renderlets-provider",
     "require": {
-        "neos/neos": "^5.0 || ^7.0"
+        "neos/neos": "^7.3 || ^8.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
- drop Neos 5.x
- raise Neos 7.x to 7.3 minimum
- allow Neos 8.x